### PR TITLE
Security/stability hardening: WebConsole CSRF, header validation, route cache

### DIFF
--- a/HlebBootstrap.php
+++ b/HlebBootstrap.php
@@ -660,10 +660,17 @@ class HlebBootstrap
         if ($server['REQUEST_METHOD'] === 'POST' && isset($post['_method']) && \is_string($post['_method'])) {
             $forced = \strtoupper($post['_method']);
             if (!$forced || $forced === 'POST') {
+            $forced = \strtoupper(\trim($post['_method']));
+            
+            // Invalid values are ignored to avoid exception-based DoS.
+            if ($forced === '' || $forced === 'POST') {
+                unset($post['_method']);
                 return null;
             }
-            if (!\in_array($forced, ['PUT', 'PATCH', 'DELETE'])) {
-                throw new RuntimeException('The `_method` value is incorrect.');
+            
+            if (!\in_array($forced, ['PUT', 'PATCH', 'DELETE'], true)) {
+                unset($post['_method']);
+                return null;
             }
             unset($post['_method']);
             $server['REQUEST_METHOD'] = $forced;

--- a/HlebBootstrap.php
+++ b/HlebBootstrap.php
@@ -657,26 +657,21 @@ class HlebBootstrap
      */
     protected function convertForcedMethod(array &$post, array &$server, ?object &$request = null): ?string
     {
-        if ($server['REQUEST_METHOD'] === 'POST' && isset($post['_method']) && \is_string($post['_method'])) {
-            $forced = \strtoupper($post['_method']);
-            if (!$forced || $forced === 'POST') {
-            $forced = \strtoupper(\trim($post['_method']));
-            
-            // Invalid values are ignored to avoid exception-based DoS.
-            if ($forced === '' || $forced === 'POST') {
-                unset($post['_method']);
-                return null;
-            }
-            
-            if (!\in_array($forced, ['PUT', 'PATCH', 'DELETE'], true)) {
-                unset($post['_method']);
-                return null;
-            }
-            unset($post['_method']);
-            $server['REQUEST_METHOD'] = $forced;
-            return $forced;
+        if (($server['REQUEST_METHOD'] ?? '') !== 'POST') {
+            return null;
         }
-        return null;
+        if (!isset($post['_method']) || !\is_string($post['_method'])) {
+            return null;
+        }
+        
+        $forced = \strtoupper(\trim($post['_method']));
+        unset($post['_method']);
+        if (!\in_array($forced, ['PUT', 'PATCH', 'DELETE'], true)) {
+            return null;
+        }
+        
+        $server['REQUEST_METHOD'] = $forced;
+        return $forced;
     }
 
     /**

--- a/HttpMethods/External/Response.php
+++ b/HttpMethods/External/Response.php
@@ -18,6 +18,16 @@ class Response
     ];
 
     private const UPPERCASE = ['MD5', 'MIME', 'TE', 'URI', 'WWW'];
+    
+    /**
+    * RFC 7230 token characters allowed in header field-name.
+    */
+    private const HEADER_NAME_CHARS = "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    
+    /**
+    * ASCII control chars (0x00–0x1F) + DEL (0x7F).
+    */
+    private const CONTROL_CHARS = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F\x7F";
 
     private array $body = [];
 
@@ -130,9 +140,11 @@ class Response
     public function getPrepareHeaders(): array
     {
         $result = [];
-        foreach ($this->headers as $name => $headers) {
-            $result[] = $name . ': ' . $headers;
-       }
+        foreach ($this->headers as $name => $values) {
+            foreach ((array)$values as $value) {
+                $result[] = $name . ': ' . $value;
+            }
+        }
         return $result;
     }
 
@@ -148,11 +160,11 @@ class Response
         $items = [];
         foreach ($headers as $name => $value) {
             try {
-                $n = $this->normalizeHeaderName((string)$name);
+                $n = $this->ensureValidHeaderName((string)$name);
             } catch (\InvalidArgumentException) {
                 continue;
             }
-
+            
             $values = \is_array($value) ? $value : [$value];
             $items[$n] = \array_map([$this, 'normalizeHeaderValue'], $values);
         }
@@ -169,13 +181,13 @@ class Response
     public function setHeader(string $name, int|float|string $value, bool $replace = true): void
     {
         try {
-            $name = $this->normalizeHeaderName($name);
+            $name = $this->ensureValidHeaderName($name);
         } catch (\InvalidArgumentException) {
             return;
         }
-
+        
         $value = $this->normalizeHeaderValue($value);
-
+        
         if ($replace) {
             $this->headers[$name] = [$value];
             return;
@@ -194,11 +206,11 @@ class Response
     public function getHeader(string $name): array
     {
         try {
-            $name = $this->normalizeHeaderName($name);
+            $name = $this->ensureValidHeaderName($name);
         } catch (\InvalidArgumentException) {
             return [];
         }
-
+        
         if (\array_key_exists($name, $this->headers)) {
             return $this->headers[$name];
         }
@@ -228,48 +240,48 @@ class Response
      */
     public function addHeaders(array $headers, bool $replace = true): void
     {
+        $parsed = [];
         foreach ($headers as $k => $val) {
             // If a value of the form ['name: value'] is received.
             // Если пришло значение вида ['название: значение'].
-            if (\is_numeric($k)) {
+            if (\is_int($k) || \ctype_digit((string)$k)) {
                 if (!\is_string($val) || !\str_contains($val, ':')) {
-                    unset($headers[$k]);
                     continue;
                 }
-
-                [$rawName, $rawValue] = \explode(':', $val, 2);
-
-                try {
-                    $name = $this->normalizeHeaderName(\trim($rawName));
-                } catch (\InvalidArgumentException) {
-                    unset($headers[$k]);
-                    continue;
-                }
-
-                $headers[$name][] = $this->normalizeHeaderValue(\trim($rawValue));
-                $headers[$name] = \array_unique($headers[$name]);
                 
-                // Do not process this numeric entry further.
-                unset($headers[$k]);
-            }
-        }
-        foreach ($headers as $key => $value) {
-            if (!\is_array($value)) {
-                $value = [$value];
-            }
-            
-            try {
-                $name = $this->normalizeHeaderName((string)$key);
-            } catch (\InvalidArgumentException) {
+                [$rawName, $rawValue] = \explode(':', $val, 2);
+                
+                try {
+                    $name = $this->ensureValidHeaderName(\trim($rawName));
+                } catch (\InvalidArgumentException) {
+                    continue;
+                }
+    
+                $parsed[$name][] = $this->normalizeHeaderValue(\trim($rawValue));
                 continue;
             }
 
-            $value = \array_map([$this, 'normalizeHeaderValue'], $value);
+            // If a value of the form ['Name' => value|[...]] is received.
+            // Если пришло значение вида ['Name' => value|[...]].
+            try {
+                $name = $this->ensureValidHeaderName((string)$k);
+            } catch (\InvalidArgumentException) {
+                continue;
+            }
             
-            if (isset($this->headers[$name])) {
-                $this->headers[$name] = \array_unique($replace ? $value : \array_merge($this->headers[$name], $value));
+            $values = \is_array($val) ? $val : [$val];
+            foreach ($values as $v) {
+                $parsed[$name][] = $this->normalizeHeaderValue($v);
+            }
+        }
+        // Apply to internal headers
+        foreach ($parsed as $name => $values) {
+            $values = \array_values(\array_unique($values));
+
+            if ($replace || !isset($this->headers[$name])) {
+                $this->headers[$name] = $values;
             } else {
-                $this->headers[$name] = \array_unique($value);
+                $this->headers[$name] = \array_values(\array_unique(\array_merge($this->headers[$name], $values)));
             }
         }
     }
@@ -361,36 +373,47 @@ class Response
         ];
     }
 
-    /**
-     * Standardizes the title for the heading.
-     *
-     * Стандартизирует название для заголовка.
-     */
-    private function normalizeHeaderName(string $name): string
+    private function isValidHeaderName(string $name): bool
     {
         $name = \trim($name);
         if ($name === '') {
-            throw new \InvalidArgumentException('Empty header name');
+            return false;
         }
+        
+        // RFC 7230 token whitelist
+        return \strspn($name, self::HEADER_NAME_CHARS) === \strlen($name);
+    }
 
-        // RFC 7230 token + explicitly deny CR/LF.
-        if (\strpbrk($name, "\r\n") !== false) {
-            throw new \InvalidArgumentException('Invalid header name');
-        }
-
-        if (!\preg_match("/^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$/", $name)) {
+    /**
+    * Validate + normalize header name before storing internally.
+    */
+    private function ensureValidHeaderName(string $name): string
+    {
+        if (!$this->isValidHeaderName($name)) {
             throw new \InvalidArgumentException('Invalid header name');
         }
         
+        return $this->normalizeHeaderName($name);
+    }
+
+    /**
+    * Standardizes the title for the heading.
+    */
+    private function normalizeHeaderName(string $name): string
+    {
+        $name = \trim($name);
+        
         $name = \str_replace('_', '-', \strtoupper($name));
         $parts = \explode('-', $name);
+        
         foreach ($parts as &$part) {
             if (\in_array($part, self::UPPERCASE, true)) {
                 continue;
             }
+        
             $part = \ucwords(\strtolower($part));
         }
-
+        
         return \implode('-', $parts);
     }
 
@@ -400,13 +423,22 @@ class Response
         if ($value === '') {
             return '';
         }
-
-        // Remove CR/LF and other control chars to prevent response splitting.
-        $clean = \preg_replace('/[\x00-\x1F\x7F]+/', '', $value);
-        if ($clean === null) {
-            $clean = '';
+        
+        if (\strcspn($value, self::CONTROL_CHARS) === \strlen($value)) {
+            return \trim($value);
         }
-
+        
+        // ASCII control chars (0x00–0x1F) + DEL (0x7F)
+        static $trans = null;
+        if ($trans === null) {
+            $trans = [];
+            for ($i = 0; $i < 32; $i++) {
+                $trans[\chr($i)] = '';
+            }
+            $trans[\chr(127)] = '';
+        }
+        
+        $clean = \strtr($value, $trans);
         return \trim($clean);
     }
 }

--- a/Init/AddressBar.php
+++ b/Init/AddressBar.php
@@ -37,7 +37,8 @@ final class AddressBar
         $this->config = $config;
         $this->request = $request;
         $this->uri = $request->getUri();
-        $this->originUrl = $this->uri->getScheme() . '://' . $this->uri->getHost() . $this->uri->getPath() . $this->uri->getQuery();
+        // Use relative URL for normalization redirects to avoid dependency on Host header.
+        $this->originUrl = $this->uri->getPath() . $this->uri->getQuery();
     }
 
     /**
@@ -80,9 +81,9 @@ final class AddressBar
         // Check for a regular expression, if it is specified in the settings.
         // Проверка на регулярное выражение, если оно задано в настройках.
         if ($validateUrl && !\preg_match($validateUrl, $urlPath)) {
-            $this->resultUrl = $this->uri->getScheme() . '://' . $this->uri->getHost();
+            $this->resultUrl = '/';
         } else {
-            $this->resultUrl = $this->uri->getScheme() . '://' . $this->uri->getHost() . $urlPath . $this->uri->getQuery();
+            $this->resultUrl = $urlPath . $this->uri->getQuery();
         }
 
         return $this;

--- a/Main/Console/Extreme/ExtremeTerminal.php
+++ b/Main/Console/Extreme/ExtremeTerminal.php
@@ -4,6 +4,8 @@
 
 namespace Hleb\Main\Console\Extreme;
 
+use Hleb\Static\Csrf;
+
 /**
  * Terminal output with interpretation of query parameters into console commands.
  *
@@ -20,9 +22,11 @@ final readonly class ExtremeTerminal
     public function get(): true
     {
         $uri = ExtremeRequest::getUri();
+        $uriEsc = \htmlspecialchars($uri, \ENT_QUOTES, 'UTF-8');
+        $csrfField = Csrf::field();
 
         echo '<h2>Terminal</h2><hr>     
-        <form name="console" action="' . $uri . '" method="post">
+        <form name="console" action="' . $uriEsc . '" method="post">' . $csrfField . '
         <table border="0" height="50" width="100%" cellpadding="0" cellspacing="0"><tr>        
         <td valign="center" width="40">        
               <input name="command" type=text autocomplete="on" formmethod="post" value="php console" placeholder="php console <command>">           
@@ -31,14 +35,14 @@ final readonly class ExtremeTerminal
         </form>  
         </td><td valign="center" width="10">              &emsp;               
         </td><td valign="center" width="20">  
-              <a href="' . $uri . '?command=php+console+--help">help</a>
+              <a href="' . $uriEsc . '?command=php+console+--help">help</a>
         </td><td valign="top" width="10">              &emsp;
-        </td><td valign="center" width="20">       
-              <a href="' . $uri . '?command=php+console+--list">list</a><br>     
+        </td><td valign="center" width="20">    
+              <a href="' . $uriEsc . '?command=php+console+--list">list</a><br>     
         </td><td valign="top" width="137">
-        <form name="close" method="post" action="' . $uri . '">
+        <form name="close" method="post" action="' . $uriEsc . '">' . $csrfField . '
         </td><td valign="center" align="right">
-              <button type="submit">Exit</button>
+              <button type="submit" name="exit" value="1">Exit</button>
         </form> 
         </td>
         </tr></table>

--- a/Main/Console/WebConsole.php
+++ b/Main/Console/WebConsole.php
@@ -9,6 +9,7 @@ use Hleb\Base\RollbackInterface;
 use Hleb\Constructor\Attributes\Accessible;
 use Hleb\Static\Request;
 use Hleb\Static\Settings;
+use Hleb\Static\Csrf;
 
 /**
  * A mechanism that allows a console application to act as a WEB site.
@@ -75,8 +76,16 @@ class WebConsole implements RollbackInterface
         }
         $transfer = new ExtremeDataTransfer();
         if ($method === 'POST') {
-            if (empty($params)) {
-                (new ExtremeIdentifier())->exit();
+            $isExit = isset($params['exit']);
+            $isCommand = \array_key_exists('command', $params);
+            if ($isExit || $isCommand) {
+                if (!Csrf::validate(Csrf::discover())) {
+                    \http_response_code(403);
+                    exit;
+                }
+                if ($isExit) {
+                    (new ExtremeIdentifier())->exit();
+                }
             }
         }
         if ($method === 'GET' && !empty($params['command'])) {

--- a/Main/Console/WebConsole.php
+++ b/Main/Console/WebConsole.php
@@ -80,8 +80,7 @@ class WebConsole implements RollbackInterface
             $isCommand = \array_key_exists('command', $params);
             if ($isExit || $isCommand) {
                 if (!Csrf::validate(Csrf::discover())) {
-                    \http_response_code(403);
-                    exit;
+                    async_exit(httpStatus: 403);
                 }
                 if ($isExit) {
                     (new ExtremeIdentifier())->exit();


### PR DESCRIPTION
| Q            | A                                                                                       |
| ------------ | --------------------------------------------------------------------------------------- |
| Is bugfix?   | **Yes**                                                                   |
| New feature? | **No**                                                                    |
| Breaks BC?   | **No** *(behavior is tighter for invalid/unsafe inputs; see notes below)* |
| Fixed issues | *(none referenced)*                                                                     |

---

### Description of the changes being made

This PR focuses on security/stability hardening and a few correctness fixes:

* Redirects during URL normalization: we build `Location` as a relative URL (`path + query`), without binding to the `Host` from the request.

* WebConsole:

  * for POST actions (`command`, `exit`) token validation is added (without it - 403);
  * links escaping in the form.

* Response headers:

  * validation of the header name correctness is added, invalid names are not accepted;
  * header values are cleaned from "breaking" characters to avoid getting a malformed response.

* `_method` (override HTTP method): invalid values are now simply ignored (without exceptions), logic is simplified.

* Route cache: when several processes rebuild at the same time, waiting with a timeout is added to avoid endless rebuild.

**Compatibility notes (why “Breaks BC” is still marked No):**

* if someone accidentally returned invalid headers, now they will be cleaned;
* POST requests to WebConsole endpoints without a CSRF token will now return 403.