### PR TITLE
FIX: Safe cache string export, WebConsole URI escaping, request normalization, realpath() handling

### DIFF
--- a/Constructor/Cache/ClassWithDataCreator.php
+++ b/Constructor/Cache/ClassWithDataCreator.php
@@ -48,7 +48,7 @@ final class ClassWithDataCreator
     private function getClassCell(string $name, int|string $value, $type): string
     {
         if ($type === 'string') {
-            $value = "'$value'";
+            $value = \var_export($value, true);
         }
         if ($type === 'integer') {
             $type = 'int';

--- a/Constructor/Data/SystemSettings.php
+++ b/Constructor/Data/SystemSettings.php
@@ -193,9 +193,14 @@ final class SystemSettings extends BaseSingleton
         if (!$path) {
             throw new DynamicStateException("The `@$keyOrPath` value was not found in the valid file path abbreviations.");
         }
-        // May not be obvious, but realpath may return false.
-        // Может быть неочевидным, но realpath может вернуть false.
-        return $ifExists ? \realpath($path) . (\str_ends_with($path, '/') ? DIRECTORY_SEPARATOR : '') : $path;
+        if (!$ifExists) {
+            return $path;
+        }
+        $real = \realpath($path);
+        if ($real === false) {
+            return false;
+        }
+        return $real . (\str_ends_with($path, '/') ? DIRECTORY_SEPARATOR : '');
     }
 
     /** @internal */

--- a/Helpers/ArrayWriting.php
+++ b/Helpers/ArrayWriting.php
@@ -49,11 +49,11 @@ final class ArrayWriting
             } else if (\is_int($key)) {
                 $tag = "$key => ";
             } else {
-                $tag = "'$key' => ";
+                $tag = \var_export((string)$key, true) . ' => ';
             }
 
             if (\is_string($value)) {
-                $value = "'$value'";
+                $value = \var_export($value, true);
             }
             if (\is_bool($value)) {
                 $value = $value ? 'true' : 'false';

--- a/HlebBootstrap.php
+++ b/HlebBootstrap.php
@@ -681,17 +681,21 @@ class HlebBootstrap
      */
     protected function standardization(): void
     {
-        $reqUri = $_SERVER['REQUEST_URI'];
+        $reqUri = (string)($_SERVER['REQUEST_URI'] ?? '/');
+        $_SERVER['REQUEST_URI'] = $reqUri;
 
         /* If the full address came in the value. */
         /* Если в значении пришёл полный адрес. */
         if (\str_starts_with($reqUri, 'http')) {
-            $_SERVER['REQUEST_SCHEME'] = \strstr($reqUri, '://', true);
-            $addr = \strstr($reqUri, '://');
-            $addr = \ltrim($addr ?: $reqUri, ':/');
-            $host = \strstr($addr, '/', true);
-            $_SERVER['REQUEST_URI'] = \strstr($addr, '/');
-            $_SERVER['HTTP_HOST'] = $host ?: $_SERVER['HTTP_HOST'];
+            $parts = \parse_url($reqUri);
+            if (\is_array($parts) && isset($parts['scheme'], $parts['host'])) {
+                $_SERVER['REQUEST_SCHEME'] = $parts['scheme'];
+                $host = $parts['host'] . (isset($parts['port']) ? ':' . $parts['port'] : '');
+                $_SERVER['HTTP_HOST'] = $host ?: (string)($_SERVER['HTTP_HOST'] ?? '');
+                $path = $parts['path'] ?? '/';
+                $query = isset($parts['query']) ? '?' . $parts['query'] : '';
+                $_SERVER['REQUEST_URI'] = $path . $query;
+            }
         }
 
         // Standardization of server values for the entire project.

--- a/Main/Console/Extreme/ExtremeRegister.php
+++ b/Main/Console/Extreme/ExtremeRegister.php
@@ -16,6 +16,7 @@ final readonly class ExtremeRegister
     public function run(): false
     {
         $uri = ExtremeRequest::getUri();
+        $uriEsc = \htmlspecialchars($uri, \ENT_QUOTES, 'UTF-8');
         $name = ExtremeIdentifier::KEY_NAME;
 
         // You can increase the strength of the key by lengthening it or adding other characters.
@@ -26,7 +27,7 @@ final readonly class ExtremeRegister
        <h2>Web Console</h2><hr>
        <p>A login key has been created in the project file: /" . $keyPath . '</p>';
         $m .= "
-        <form name='register' action='$uri' method='post' autocomplete='off'>
+        <form name='register' action='$uriEsc' method='post' autocomplete='off'>
            Login key: <input name='$name' type='text' value='' autocomplete='off' minlength='72'><button type='submit'>Send</button>
         </form>";
         echo $m;


### PR DESCRIPTION
| Q            | A                                                         |
|--------------|-----------------------------------------------------------|
| Is bugfix?   | **Yes**                                              |
| New feature? | **No**                                              |
| Breaks BC?   | **No**                                              |
| Fixed issues | -                                                         |

------

### Description of the changes being made

This PR contains several targeted fixes focused on stability and security hardening in edge cases, without changing public APIs.

**1) Safe string export in cache/code generation**
Replaced manual `'...'` string building with `var_export()` for string values/keys to avoid broken PHP output when data contains quotes, slashes or control characters.
Touched: `Helpers/ArrayWriting.php`, `Constructor/Cache/ClassWithDataCreator.php`

**2) Web Console: escape URI used in form action**
`REQUEST_URI` (current URI) is now escaped via `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` before being placed into `<form action=...>`, preventing XSS via crafted request targets.
Touched: `Main/Console/Extreme/ExtremeRegister.php`

**3) Bootstrap: more robust request target normalization**
`standardization()` no longer depends strictly on `$_SERVER['REQUEST_URI']` presence.
If a full URL appears in `REQUEST_URI` (proxy / non-standard server setups), parsing is now done via `parse_url()` and `REQUEST_URI` is rebuilt as `path + query` safely (no warnings, fewer inconsistent states).
Touched: `HlebBootstrap.php`

**4) Alias path: correct handling of realpath() failure**
`realpath()` may return `false`; this is now handled explicitly so the method returns `false` instead of producing an invalid/empty path string.
Touched: `Constructor/Data/SystemSettings.php`
